### PR TITLE
added patch for missing fullComponentData prop on new workspaces

### DIFF
--- a/redux/user/workspaces/workspacesActionCreators.js
+++ b/redux/user/workspaces/workspacesActionCreators.js
@@ -236,7 +236,12 @@ export const createNewWorkspace = (name, domain, credentials) => async (dispatch
     });
 
     const key = response.data._id;
-    const value = response.data;
+    const value = {
+      ...response.data,
+      fullComponentData: {} // temporary patch until added to backend
+      // without this code, error is thrown when a newly created workspace loads and tries to access the field
+    };
+
     dispatch(setOneWorkspace(key, value)); // dispatch key-val pair where _id is the key
   } catch (err) {
     dispatch(


### PR DESCRIPTION
An error was getting thrown whenever a user created a new workspace and then immediately attempted to access that workspace item. As a temporary fix, I added an additional property, `fullComponentData: {}`, to the response data in the workspace actionCreator/thunk `createNewWorkspace` before the data is dispatched. The function is located in the file `src/redux/user/workspaces/workspacesActionCreators.js`, and I have included a snippet of the changes below.

```js
    const key = response.data._id;
    const value = {
      ...response.data,
      fullComponentData: {} // temporary patch until added to backend
      // without this code, error is thrown when a newly created workspace loads and tries to access the field
    };

    dispatch(setOneWorkspace(key, value)); // dispatch key-val pair where _id is the key
```