### PR TITLE
Fixed  a couple of bugs in QuestionComponent

### DIFF
--- a/components/QuestionComponent/index.js
+++ b/components/QuestionComponent/index.js
@@ -95,7 +95,6 @@ const QuestionComponent = ({ _id, question, questionCategory, workspaceId, answe
                 content: 'Save',
                 disabled: !unsavedChanges
               }}
-              // actionPosition="right"
               error={error.hasError}
             />
           </Form>


### PR DESCRIPTION
- Removed `defaultValue`, because it conflicted with `value`.
- Changed wrapper of text input component from `Form.Field` to `Input`. This involved additionally removing the prop `control={Input}` from what was `Form.Field`.
- Removed `actionPosition` prop because it was, for the same reason, incorrect and unnecessary. The `actionPosition` prop is accepted by a `Form.Field` component that also takes an inline `action` prop and object and designates the side to which the action button will be attached. But because absent `actionPosition` the action button defaults to the right side, it only accepts 'left' when specified at all.
- Removed placeholder prop