### PR TITLE
Fixed bug in AJAX request on CTA email capture

### DIFF
--- a/components/Banner/index.js
+++ b/components/Banner/index.js
@@ -10,13 +10,12 @@ import { Message } from 'semantic-ui-react';
  * @param {String} content.header Header string for banner
  * @param {String} content.paragraphHTML pargraph string that can contain be html
  */
-const Banner = ({ content }) => {
-  const { header, paragraphHTML } = content;
+const Banner = ({ header, paragraph }) => {
   return (
     <>
       <Message positive>
         <Message.Header>{header}</Message.Header>
-        <p>{paragraphHTML}</p>
+        <p>{paragraph}</p>
       </Message>
     </>
   );

--- a/components/EmailCapture/apis/index.js
+++ b/components/EmailCapture/apis/index.js
@@ -32,14 +32,11 @@ export const submitEmail = async (emailString) => {
     };
 
     // make request and store response in variable
-    const { message } = await axios(config);
+    const response = await axios(config); // should contain `message` property
 
     // returns the message property from response obj, which will
     // be displayed on client as a success banner.
-    return {
-      header: message.header,
-      paragraphHTML: message.paragraph
-    };
+    return response.data.message; // should contain `header` and `paragraph` properties
   } catch (err) {
     // handle and re-format an unformatted errors
     throw new EarlystageError(err.message, err.statusCode || 500);

--- a/components/EmailCapture/index.js
+++ b/components/EmailCapture/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form, Input, Popup, Label } from 'semantic-ui-react';
+import { Form, Input, Label } from 'semantic-ui-react';
 import useEmailCapture from './useEmailCapture';
 import Banner from '../Banner';
 
@@ -28,7 +28,7 @@ const EmailCapture = () => {
           />
         </Form.Field>
       </Form>
-      {banner ? <Banner content={{ ...banner }} /> : null}
+      {banner ? <Banner header={banner.header} paragraph={banner.paragraph} /> : null}
     </>
   );
 };

--- a/components/EmailCapture/useEmailCapture.js
+++ b/components/EmailCapture/useEmailCapture.js
@@ -37,10 +37,10 @@ const useEmailCapture = () => {
       clientValidation(email);
 
       // submit email to server if client validation is passed
-      const { message } = await submitEmail(email);
+      const response = await submitEmail(email);
 
       // set the banner message to response string
-      setBanner(() => ({ header: message.header, paragraphHTML: message.paragraph }));
+      setBanner(() => ({ header: response.header, paragraph: response.paragraph }));
 
       setIsLoading(() => false);
     } catch (err) {


### PR DESCRIPTION
## Summary
The program was crashing when a valid email submitted to the server through a CTA email capture form on the landing page. Specifically, it was trying to get the properties `header` and `paragraph` from a variable with an `undefined` value. The server was successfully returning a `200` status code with a of response body of `message: { header: <String>, paragraph: <String> }` from the `POST /register` endpoint, but inside of `submitEmail()`, the client was parsing `response.message` instead of `response.data.message`. This is a feature of axios and has now been resolved.