### PR TITLE
Updated build command to fix bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
   "scripts": {
     "test": "jest",
     "dev": "next",
-    "build": "next build",
+    "build": "npx next build",
     "start": "next start",
-    "export": "npm run build && npx next export",
     "now-build": "npm run semantic:build && next build",
     "semantic:build": "cd .semantic && gulp build-css build-assets",
     "semantic:watch": "cd .semantic && npm run semantic:build && gulp watch",


### PR DESCRIPTION
## Summary
Updated build command from `export: npm run build && npx next export` to `build: npx next build`. This was required because next cannot export dynamically routed SSR pages.